### PR TITLE
CI: Add Test & Deploy GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Test Books API
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12.1
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.12.1"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: "Deploy"
+
+on:
+  pull_request:
+    types:
+      - merged
+
+  deploy:
+      name: Deploy to EC2 Instance
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout the code
+          uses: actions/checkout@v2
+
+        - name: Deploy to my EC2 instance
+          uses: easingthemes/ssh-deploy@main
+          env:
+            SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_KEY }}
+            SOURCE: "./"
+            REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+            REMOTE_USER: ${{ secrets.REMOTE_USER }}
+            TARGET: ${{ REMOTE_TARGET }}


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for testing and deploying the Books API. The most important changes include setting up a CI workflow for running tests and a deployment workflow for deploying to an EC2 instance.

### CI Workflow Setup:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R27): Added a new workflow to run tests on pull requests to the `main` branch using Python 3.12.1 and `pytest`.

### Deployment Workflow Setup:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R23): Added a new workflow to deploy the application to an EC2 instance upon merging pull requests.