### PR TITLE
Fix: Add the missing `jobs` section and run commands after copying files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,19 +5,31 @@ on:
     types:
       - merged
 
+jobs:
   deploy:
-      name: Deploy to EC2 Instance
-      runs-on: ubuntu-latest
+    name: Deploy to EC2 Instance
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Checkout the code
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
 
-        - name: Deploy to my EC2 instance
-          uses: easingthemes/ssh-deploy@main
-          env:
-            SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_KEY }}
-            SOURCE: "./"
-            REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
-            REMOTE_USER: ${{ secrets.REMOTE_USER }}
-            TARGET: ${{ REMOTE_TARGET }}
+      - name: Deploy to my EC2 instance
+        uses: easingthemes/ssh-deploy@main
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_KEY }}
+          SOURCE: "./"
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          TARGET: ${{ REMOTE_TARGET }}
+          SCRIPT_AFTER: |
+            cd fastapi-book-project
+            if [ -f '/.venv' ]; then 
+              source .venv/bin/activate
+            else
+              python3 -m venv .venv
+              source .venv/bin/activate
+            fi
+
+            pip install -r requirements.txt
+            sudo systemctl restart books-api.service


### PR DESCRIPTION
This pull request introduces a new deployment job to the GitHub Actions workflow for deploying to an EC2 instance. The most important changes include the addition of a new deployment job, the setup script for the virtual environment, and the service restart.

Deployment job addition:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R8): Added a new job named `deploy` that runs on `ubuntu-latest` to handle deployment to an EC2 instance.

Virtual environment and service setup:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R25-R35): Added a script to set up a Python virtual environment, install required packages, and restart the `books-api.service`.