### PR TITLE
ci: Add the main branch as the only one to run the deploy action on

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - merged
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change specifies that the deployment workflow should only run on the `main` branch when a pull request is merged. 

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R7): Added the `branches: [main]` configuration to the `pull_request` event to ensure the deployment job only runs on the `main` branch.