### PR TITLE
CI: Use the closed event for pull request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: "Deploy"
 on:
   pull_request:
     types:
-      - merged
+      - closed
     branches: [main]
 
 jobs:


### PR DESCRIPTION
This pull request includes a change to the deployment workflow in the `.github/workflows/deploy.yml` file. The change adjusts the trigger for the deployment job to run on closed pull requests instead of merged pull requests, which is the incorrect event.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-R6): Changed the `pull_request` event type from `merged` to `closed` for the deployment workflow.