### PR TITLE
CI: Run deploy action only when the tests pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,15 @@
 name: "Deploy"
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches: [main]
+  workflow_run:
+    workflows: ["Test Books API"]
+    types: [completed]
+
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -36,5 +38,5 @@ jobs:
             sudo systemctl restart books-api.service
 
             # Run the healthchecks to verify everything went well
-            curl localhost:80/healthcheck ; echo
+            curl http://${{ secrets.REMOTE_HOST }}/healthcheck ; echo
             echo "Deployed successfully"


### PR DESCRIPTION
This pull request includes updates to the deployment workflow, which will trigger deployments based on the completion of a specific workflow and improve the process by using a secret for the remote host.

Changes to deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R12): Modified the deployment workflow to trigger on the completion of the "Test Books API" workflow instead of on pull request closure.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R12): Added a condition to only run the deployment job if the previous workflow concluded successfully.

Improvements to deployment process:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L39-R41): Changed the healthcheck URL to use a secret for the remote host, enhancing security.