### PR TITLE
CI: Test and deploy after pull request is merged into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [main]
 
-  push:
-    branches: [main]
-
 permissions:
   contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,30 @@
-name: "Deploy"
+name: "Test and Deploy"
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python -m pytest
+
   deploy:
     needs: [test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
@@ -26,7 +45,9 @@ jobs:
               python3 -m venv .venv
               source .venv/bin/activate
             fi
+
             pip install -r requirements.txt
             sudo systemctl restart books-api.service
+
             curl http://${{ secrets.REMOTE_HOST }}/healthcheck ; echo
             echo "Deployed successfully"


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows for continuous integration and deployment. The most important changes involve adding a testing job to the deployment workflow and modifying the deployment job's conditions.

Changes to `.github/workflows/ci.yml`:

* Removed the `push` event trigger, so the workflow now only runs on pull requests to the `main` branch.

Changes to `.github/workflows/deploy.yml`:

* Renamed the workflow from "Deploy" to "Test and Deploy" and added a `test` job that runs on pull requests to the `main` branch. This job sets up Python, installs dependencies, and runs tests using `pytest`.
* Modified the `deploy` job to depend on the `test` job and to only run on `push` events to the `main` branch.
* Added a condition to the `deploy` job to ensure it only runs if the event is a push to the `main` branch.